### PR TITLE
Omnia/feature/45 create nova resources

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,11 +17,11 @@
     "require": {
         "php": "^7.3|^8.0",
         "drewroberts/media": "^3.2.2",
-        "tipoff/addresses": "^2.0.0",
-        "tipoff/authorization": "^2.3.1",
+        "tipoff/addresses": "^2.2.0",
+        "tipoff/authorization": "^2.3.2",
         "tipoff/laravel-google-api": "^1.3.1",
         "tipoff/laravel-serpapi": "^1.0.4",
-        "tipoff/support": "^1.5.8"
+        "tipoff/support": "^1.5.10"
     },
     "require-dev": {
         "tipoff/test-support": "^1.2.0"

--- a/src/Nova/Company.php
+++ b/src/Nova/Company.php
@@ -34,11 +34,18 @@ class Company extends BaseResource
             Text::make('Name')->required(),
             Text::make('Slug')->required()->creationRules('unique:companies,slug'),
 
-            new Panel('Data Fields', [
-                $this->dataFields(),
-                $this->creatorDataFields(),
-                $this->updaterDataFields()
-            ]),
+            new Panel('Data Fields', $this->dataFields()),
         ]);
+    }
+
+    public function dataFields(): array
+    {
+        return array_merge(
+            parent::dataFields(),
+            [
+                $this->creatorDataFields(),
+                $this->updaterDataFields(),
+            ]
+        );
     }
 }

--- a/src/Nova/Company.php
+++ b/src/Nova/Company.php
@@ -32,7 +32,7 @@ class Company extends BaseResource
     {
         return array_filter([
             Text::make('Name')->required(),
-            Text::make('Slug')->required()->creationRules('unique:companies,slug'),
+            Text::make('Slug')->required()->creationRules('unique:companies,slug')->sortable(),
 
             new Panel('Data Fields', $this->dataFields()),
         ]);

--- a/src/Nova/Company.php
+++ b/src/Nova/Company.php
@@ -12,7 +12,7 @@ use Laravel\Nova\Http\Requests\NovaRequest;
 use Laravel\Nova\Panel;
 use Tipoff\Support\Nova\BaseResource;
 
-class ProfileLink extends BaseResource
+class Company extends BaseResource
 {
     public static $model = \Tipoff\Seo\Models\Company::class;
 

--- a/src/Nova/Company.php
+++ b/src/Nova/Company.php
@@ -31,8 +31,8 @@ class Company extends BaseResource
     public function fields(Request $request)
     {
         return array_filter([
-            Text::make('name')->required(),
-            Text::make('slug')->required()->creationRules('unique:companies,slug'),
+            Text::make('Name')->required(),
+            Text::make('Slug')->required()->creationRules('unique:companies,slug'),
 
             new Panel('Data Fields', [
                 $this->dataFields(),

--- a/src/Nova/Company.php
+++ b/src/Nova/Company.php
@@ -7,7 +7,6 @@ namespace Tipoff\Seo\Nova;
 use Illuminate\Http\Request;
 use Laravel\Nova\Fields\ID;
 use Laravel\Nova\Fields\Text;
-use Laravel\Nova\Fields\Date;
 use Laravel\Nova\Http\Requests\NovaRequest;
 use Laravel\Nova\Panel;
 use Tipoff\Support\Nova\BaseResource;
@@ -35,16 +34,11 @@ class Company extends BaseResource
             Text::make('name')->required(),
             Text::make('slug')->required()->creationRules('unique:companies,slug'),
 
-            new Panel('Data Fields', $this->dataFields()),
-        ]);
-    }
-
-    protected function dataFields(): array
-    {
-        return array_filter([
-            ID::make(),
-            Date::make('Created At')->exceptOnForms(),
-            Date::make('Updated At')->exceptOnForms(),
+            new Panel('Data Fields', [
+                $this->dataFields(),
+                $this->creatorDataFields(),
+                $this->updaterDataFields()
+            ]),
         ]);
     }
 }

--- a/src/Nova/Company.php
+++ b/src/Nova/Company.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tipoff\Seo\Nova;
+
+use Illuminate\Http\Request;
+use Laravel\Nova\Fields\ID;
+use Laravel\Nova\Fields\Text;
+use Laravel\Nova\Fields\Date;
+use Laravel\Nova\Http\Requests\NovaRequest;
+use Laravel\Nova\Panel;
+use Tipoff\Support\Nova\BaseResource;
+
+class ProfileLink extends BaseResource
+{
+    public static $model = \Tipoff\Seo\Models\Company::class;
+
+    public static $title = 'name';
+
+    public static $search = [
+        'id',
+    ];
+
+    public function fieldsForIndex(NovaRequest $request)
+    {
+        return array_filter([
+            ID::make()->sortable(),
+        ]);
+    }
+
+    public function fields(Request $request)
+    {
+        return array_filter([
+            Text::make('name')->required(),
+            Text::make('slug')->required()->creationRules('unique:companies,slug'),
+
+            new Panel('Data Fields', $this->dataFields()),
+        ]);
+    }
+
+    protected function dataFields(): array
+    {
+        return array_filter([
+            ID::make(),
+            Date::make('Created At')->exceptOnForms(),
+            Date::make('Updated At')->exceptOnForms(),
+        ]);
+    }
+}

--- a/src/Nova/CompanyUser.php
+++ b/src/Nova/CompanyUser.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace Tipoff\Seo\Nova;
 
 use Illuminate\Http\Request;
-use Laravel\Nova\Fields\ID;
-use Laravel\Nova\Fields\Boolean;
 use Laravel\Nova\Fields\BelongsTo;
+use Laravel\Nova\Fields\Boolean;
+use Laravel\Nova\Fields\ID;
 use Laravel\Nova\Http\Requests\NovaRequest;
 use Laravel\Nova\Panel;
 use Tipoff\Support\Nova\BaseResource;

--- a/src/Nova/CompanyUser.php
+++ b/src/Nova/CompanyUser.php
@@ -31,7 +31,7 @@ class CompanyUser extends BaseResource
     public function fields(Request $request)
     {
         return array_filter([
-            Boolean::make('primary contact')->required(),
+            Boolean::make('Primary contact')->required(),
 
             new Panel('Data Fields', [
                 $this->dataFields(),

--- a/src/Nova/CompanyUser.php
+++ b/src/Nova/CompanyUser.php
@@ -36,11 +36,18 @@ class CompanyUser extends BaseResource
             nova('company') ? BelongsTo::make('Company', 'company', nova('company'))->searchable() : null,
             nova('user') ? BelongsTo::make('User', 'user', nova('user'))->searchable() : null,
 
-            new Panel('Data Fields', [
-                $this->dataFields(),
-                $this->creatorDataFields(),
-                $this->updaterDataFields()
-            ]),
+            new Panel('Data Fields', $this->dataFields()),
         ]);
+    }
+
+    public function dataFields(): array
+    {
+        return array_merge(
+            parent::dataFields(),
+            [
+                $this->creatorDataFields(),
+                $this->updaterDataFields(),
+            ]
+        );
     }
 }

--- a/src/Nova/CompanyUser.php
+++ b/src/Nova/CompanyUser.php
@@ -6,8 +6,6 @@ namespace Tipoff\Seo\Nova;
 
 use Illuminate\Http\Request;
 use Laravel\Nova\Fields\ID;
-use Laravel\Nova\Fields\Text;
-use Laravel\Nova\Fields\Date;
 use Laravel\Nova\Fields\Boolean;
 use Laravel\Nova\Http\Requests\NovaRequest;
 use Laravel\Nova\Panel;
@@ -35,16 +33,11 @@ class CompanyUser extends BaseResource
         return array_filter([
             Boolean::make('primary contact')->required(),
 
-            new Panel('Data Fields', $this->dataFields()),
-        ]);
-    }
-
-    protected function dataFields(): array
-    {
-        return array_filter([
-            ID::make(),
-            Date::make('Created At')->exceptOnForms(),
-            Date::make('Updated At')->exceptOnForms(),
+            new Panel('Data Fields', [
+                $this->dataFields(),
+                $this->creatorDataFields(),
+                $this->updaterDataFields()
+            ]),
         ]);
     }
 }

--- a/src/Nova/CompanyUser.php
+++ b/src/Nova/CompanyUser.php
@@ -7,6 +7,7 @@ namespace Tipoff\Seo\Nova;
 use Illuminate\Http\Request;
 use Laravel\Nova\Fields\ID;
 use Laravel\Nova\Fields\Boolean;
+use Laravel\Nova\Fields\BelongsTo;
 use Laravel\Nova\Http\Requests\NovaRequest;
 use Laravel\Nova\Panel;
 use Tipoff\Support\Nova\BaseResource;
@@ -32,6 +33,8 @@ class CompanyUser extends BaseResource
     {
         return array_filter([
             Boolean::make('Primary contact')->required(),
+            nova('company') ? BelongsTo::make('Company', 'company', nova('company'))->searchable() : null,
+            nova('user') ? BelongsTo::make('User', 'user', nova('user'))->searchable() : null,
 
             new Panel('Data Fields', [
                 $this->dataFields(),

--- a/src/Nova/CompanyUser.php
+++ b/src/Nova/CompanyUser.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tipoff\Seo\Nova;
+
+use Illuminate\Http\Request;
+use Laravel\Nova\Fields\ID;
+use Laravel\Nova\Fields\Text;
+use Laravel\Nova\Fields\Date;
+use Laravel\Nova\Fields\Boolean;
+use Laravel\Nova\Http\Requests\NovaRequest;
+use Laravel\Nova\Panel;
+use Tipoff\Support\Nova\BaseResource;
+
+class CompanyUser extends BaseResource
+{
+    public static $model = \Tipoff\Seo\Models\CompanyUser::class;
+
+    public static $title = 'name';
+
+    public static $search = [
+        'id',
+    ];
+
+    public function fieldsForIndex(NovaRequest $request)
+    {
+        return array_filter([
+            ID::make()->sortable(),
+        ]);
+    }
+
+    public function fields(Request $request)
+    {
+        return array_filter([
+            Boolean::make('primary contact')->required(),
+
+            new Panel('Data Fields', $this->dataFields()),
+        ]);
+    }
+
+    protected function dataFields(): array
+    {
+        return array_filter([
+            ID::make(),
+            Date::make('Created At')->exceptOnForms(),
+            Date::make('Updated At')->exceptOnForms(),
+        ]);
+    }
+}

--- a/src/Nova/Domain.php
+++ b/src/Nova/Domain.php
@@ -38,7 +38,7 @@ class Domain extends BaseResource
             Boolean::make('Https')->required()->default(true),
             Text::make('Subdomain')->nullable(),
 
-            nova('company') ? BelongsTo::make('Company', 'company', nova('company'))->searchable() : null,
+            nova('company') ? BelongsTo::make('Company', 'company', nova('company'))->nullable() : null,
 
             new Panel('Data Fields', $this->dataFields()),
         ]);

--- a/src/Nova/Domain.php
+++ b/src/Nova/Domain.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tipoff\Seo\Nova;
+
+use Illuminate\Http\Request;
+use Laravel\Nova\Fields\ID;
+use Laravel\Nova\Fields\Text;
+use Laravel\Nova\Fields\Boolean;
+use Laravel\Nova\Fields\BelongsTo;
+use Laravel\Nova\Http\Requests\NovaRequest;
+use Laravel\Nova\Panel;
+use Tipoff\Support\Nova\BaseResource;
+
+class Domain extends BaseResource
+{
+    public static $model = \Tipoff\Seo\Models\Domain::class;
+
+    public static $title = 'name';
+
+    public static $search = [
+        'id',
+    ];
+
+    public function fieldsForIndex(NovaRequest $request)
+    {
+        return array_filter([
+            ID::make()->sortable(),
+        ]);
+    }
+
+    public function fields(Request $request)
+    {
+        return array_filter([
+            Text::make('Name')->required(),
+            Text::make('Tld')->required(),
+            Boolean::make('Https')->required()->default(true),
+            Text::make('Subdomain')->nullable(),
+
+            nova('company') ? BelongsTo::make('Company', 'company', nova('company'))->searchable() : null,
+
+            new Panel('Data Fields', $this->dataFields()),
+        ]);
+    }
+
+    public function dataFields(): array
+    {
+        return array_merge(
+            parent::dataFields(),
+            [
+                $this->creatorDataFields(),
+                $this->updaterDataFields(),
+            ]
+        );
+    }
+}

--- a/src/Nova/Domain.php
+++ b/src/Nova/Domain.php
@@ -5,10 +5,10 @@ declare(strict_types=1);
 namespace Tipoff\Seo\Nova;
 
 use Illuminate\Http\Request;
+use Laravel\Nova\Fields\BelongsTo;
+use Laravel\Nova\Fields\Boolean;
 use Laravel\Nova\Fields\ID;
 use Laravel\Nova\Fields\Text;
-use Laravel\Nova\Fields\Boolean;
-use Laravel\Nova\Fields\BelongsTo;
 use Laravel\Nova\Http\Requests\NovaRequest;
 use Laravel\Nova\Panel;
 use Tipoff\Support\Nova\BaseResource;

--- a/src/Nova/Keyword.php
+++ b/src/Nova/Keyword.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tipoff\Seo\Nova;
+
+use Illuminate\Http\Request;
+use Laravel\Nova\Fields\ID;
+use Laravel\Nova\Fields\Text;
+use Laravel\Nova\Fields\BelongsTo;
+use Laravel\Nova\Http\Requests\NovaRequest;
+use Laravel\Nova\Panel;
+use Tipoff\Support\Nova\BaseResource;
+
+class Keyword extends BaseResource
+{
+    public static $model = \Tipoff\Seo\Models\Keyword::class;
+
+    public static $title = 'phrase';
+
+    public static $search = [
+        'id',
+    ];
+
+    public function fieldsForIndex(NovaRequest $request)
+    {
+        return array_filter([
+            ID::make()->sortable(),
+        ]);
+    }
+
+    public function fields(Request $request)
+    {
+        return array_filter([
+            Text::make('Phrase')->required()->rules('required')->creationRules('unique:keywords,phrase')->sortable(),
+            Text::make('Type')->required()->rules('required')->sortable(),
+
+            nova('keyword') ? BelongsTo::make('Keyword', 'keyword', nova('keyword'))->searchable()->nullable() : null,
+
+            new Panel('Data Fields', $this->dataFields()),
+        ]);
+    }
+
+    public function dataFields(): array
+    {
+        return array_merge(
+            parent::dataFields(),
+            [
+                $this->creatorDataFields(),
+                $this->updaterDataFields(),
+            ]
+        );
+    }
+}

--- a/src/Nova/Keyword.php
+++ b/src/Nova/Keyword.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace Tipoff\Seo\Nova;
 
 use Illuminate\Http\Request;
+use Laravel\Nova\Fields\BelongsTo;
 use Laravel\Nova\Fields\ID;
 use Laravel\Nova\Fields\Text;
-use Laravel\Nova\Fields\BelongsTo;
 use Laravel\Nova\Http\Requests\NovaRequest;
 use Laravel\Nova\Panel;
 use Tipoff\Support\Nova\BaseResource;

--- a/src/Nova/Keyword.php
+++ b/src/Nova/Keyword.php
@@ -32,10 +32,10 @@ class Keyword extends BaseResource
     public function fields(Request $request)
     {
         return array_filter([
-            Text::make('Phrase')->required()->rules('required')->creationRules('unique:keywords,phrase')->sortable(),
-            Text::make('Type')->required()->rules('required')->sortable(),
+            Text::make('Phrase')->required()->creationRules('unique:keywords,phrase')->sortable(),
+            Text::make('Type')->required()->sortable(),
 
-            nova('keyword') ? BelongsTo::make('Keyword', 'keyword', nova('keyword'))->searchable()->nullable() : null,
+            nova('keyword') ? BelongsTo::make('Parent phrase', 'parent phrase', nova('keyword'))->nullable() : null,
 
             new Panel('Data Fields', $this->dataFields()),
         ]);

--- a/src/Nova/Place.php
+++ b/src/Nova/Place.php
@@ -5,10 +5,10 @@ declare(strict_types=1);
 namespace Tipoff\Seo\Nova;
 
 use Illuminate\Http\Request;
-use Laravel\Nova\Fields\ID;
-use Laravel\Nova\Fields\Text;
 use Laravel\Nova\Fields\BelongsTo;
+use Laravel\Nova\Fields\ID;
 use Laravel\Nova\Fields\MorphMany;
+use Laravel\Nova\Fields\Text;
 use Laravel\Nova\Http\Requests\NovaRequest;
 use Laravel\Nova\Panel;
 use Tipoff\Support\Nova\BaseResource;

--- a/src/Nova/Place.php
+++ b/src/Nova/Place.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tipoff\Seo\Nova;
+
+use Illuminate\Http\Request;
+use Laravel\Nova\Fields\ID;
+use Laravel\Nova\Fields\Text;
+use Laravel\Nova\Fields\BelongsTo;
+use Laravel\Nova\Http\Requests\NovaRequest;
+use Laravel\Nova\Panel;
+use Tipoff\Support\Nova\BaseResource;
+
+class Place extends BaseResource
+{
+    public static $model = \Tipoff\Seo\Models\Place::class;
+
+    public static $title = 'name';
+
+    public static $search = [
+        'id',
+    ];
+
+    public function fieldsForIndex(NovaRequest $request)
+    {
+        return array_filter([
+            ID::make()->sortable(),
+        ]);
+    }
+
+    public function fields(Request $request)
+    {
+        return array_filter([
+            Text::make('Place location')->required()->creationRules('unique:places,place_location'),
+            Text::make('Name')->nullable(),
+
+            nova('webpage') ? BelongsTo::make('Webpage', 'webpage', nova('webpage'))->nullable() : null,
+            nova('company') ? BelongsTo::make('Company', 'company', nova('company'))->nullable() : null,
+
+            new Panel('Data Fields', $this->dataFields()),
+        ]);
+    }
+
+    public function dataFields(): array
+    {
+        return array_merge(
+            parent::dataFields(),
+            [
+                $this->creatorDataFields(),
+                $this->updaterDataFields(),
+            ]
+        );
+    }
+}

--- a/src/Nova/Place.php
+++ b/src/Nova/Place.php
@@ -8,6 +8,7 @@ use Illuminate\Http\Request;
 use Laravel\Nova\Fields\ID;
 use Laravel\Nova\Fields\Text;
 use Laravel\Nova\Fields\BelongsTo;
+use Laravel\Nova\Fields\MorphMany;
 use Laravel\Nova\Http\Requests\NovaRequest;
 use Laravel\Nova\Panel;
 use Tipoff\Support\Nova\BaseResource;
@@ -37,6 +38,7 @@ class Place extends BaseResource
 
             nova('webpage') ? BelongsTo::make('Webpage', 'webpage', nova('webpage'))->nullable() : null,
             nova('company') ? BelongsTo::make('Company', 'company', nova('company'))->nullable() : null,
+            MorphMany::make('Results'),
 
             new Panel('Data Fields', $this->dataFields()),
         ]);

--- a/src/Nova/PlaceDetails.php
+++ b/src/Nova/PlaceDetails.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tipoff\Seo\Nova;
+
+use Illuminate\Http\Request;
+use Laravel\Nova\Fields\Date;
+use Laravel\Nova\Fields\ID;
+use Laravel\Nova\Fields\Text;
+use Laravel\Nova\Fields\BelongsTo;
+use Laravel\Nova\Http\Requests\NovaRequest;
+use Laravel\Nova\Panel;
+use Tipoff\Support\Nova\BaseResource;
+
+class PlaceDetails extends BaseResource
+{
+    public static $model = \Tipoff\Seo\Models\PlaceDetails::class;
+
+    public static $title = 'name';
+
+    public static $search = [
+        'id',
+    ];
+
+    public function fieldsForIndex(NovaRequest $request)
+    {
+        return array_filter([
+            ID::make()->sortable(),
+        ]);
+    }
+
+    public function fields(Request $request)
+    {
+        return array_filter([
+            Text::make('Name')->required(),
+            Date::make('Opened at')->nullable(),
+            Text::make('Address')->nullable(),
+            Text::make('Address2')->nullable(),
+            Text::make('City')->nullable(),
+            Text::make('State')->nullable(),
+            Text::make('Zip')->rules('max:5')->nullable(),
+            Text::make('Phone')->rules('max:25')->nullable(),
+            Text::make('Maps url')->nullable(),
+            Text::make('Latitude')->nullable(),
+            Text::make('Longitude')->nullable(),
+
+            nova('place') ? BelongsTo::make('Place', 'place', nova('place'))->sortable() : null,
+            nova('webpage') ? BelongsTo::make('Webpage', 'webpage', nova('webpage'))->nullable() : null,
+
+            new Panel('Data Fields', $this->dataFields()),
+        ]);
+    }
+
+    public function dataFields(): array
+    {
+        return array_merge(
+            parent::dataFields(),
+            [
+                $this->creatorDataFields(),
+            ]
+        );
+    }
+}

--- a/src/Nova/PlaceDetails.php
+++ b/src/Nova/PlaceDetails.php
@@ -5,10 +5,10 @@ declare(strict_types=1);
 namespace Tipoff\Seo\Nova;
 
 use Illuminate\Http\Request;
+use Laravel\Nova\Fields\BelongsTo;
 use Laravel\Nova\Fields\Date;
 use Laravel\Nova\Fields\ID;
 use Laravel\Nova\Fields\Text;
-use Laravel\Nova\Fields\BelongsTo;
 use Laravel\Nova\Http\Requests\NovaRequest;
 use Laravel\Nova\Panel;
 use Tipoff\Support\Nova\BaseResource;

--- a/src/Nova/PlaceHours.php
+++ b/src/Nova/PlaceHours.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tipoff\Seo\Nova;
+
+use Illuminate\Http\Request;
+use Laravel\Nova\Fields\ID;
+use Laravel\Nova\Fields\Text;
+use Laravel\Nova\Fields\BelongsTo;
+use Laravel\Nova\Http\Requests\NovaRequest;
+use Laravel\Nova\Panel;
+use Tipoff\Support\Nova\BaseResource;
+
+class PlaceHours extends BaseResource
+{
+    public static $model = \Tipoff\Seo\Models\PlaceHours::class;
+
+    public static $title;
+
+    public static $search = [
+        'id',
+    ];
+
+    public function fieldsForIndex(NovaRequest $request)
+    {
+        return array_filter([
+            ID::make()->sortable(),
+        ]);
+    }
+
+    public function fields(Request $request)
+    {
+        return array_filter([
+            Text::make('Monday open')->nullable(),
+            Text::make('Monday close')->nullable(),
+            Text::make('Tuesday open')->nullable(),
+            Text::make('Tuesday close')->nullable(),
+            Text::make('Wednesday open')->nullable(),
+            Text::make('Wednesday close')->nullable(),
+            Text::make('Thursday open')->nullable(),
+            Text::make('Thursday close')->nullable(),
+            Text::make('Friday open')->nullable(),
+            Text::make('Friday close')->nullable(),
+            Text::make('Saturday open')->nullable(),
+            Text::make('Saturday close')->nullable(),
+            Text::make('Sunday open')->nullable(),
+            Text::make('Sunday close')->nullable(),
+
+            nova('place') ? BelongsTo::make('Place', 'place', nova('place'))->sortable() : null,
+
+            new Panel('Data Fields', $this->dataFields()),
+        ]);
+    }
+
+    public function dataFields(): array
+    {
+        return array_merge(
+            parent::dataFields(),
+            [
+                $this->creatorDataFields(),
+            ]
+        );
+    }
+}

--- a/src/Nova/PlaceHours.php
+++ b/src/Nova/PlaceHours.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace Tipoff\Seo\Nova;
 
 use Illuminate\Http\Request;
+use Laravel\Nova\Fields\BelongsTo;
 use Laravel\Nova\Fields\ID;
 use Laravel\Nova\Fields\Text;
-use Laravel\Nova\Fields\BelongsTo;
 use Laravel\Nova\Http\Requests\NovaRequest;
 use Laravel\Nova\Panel;
 use Tipoff\Support\Nova\BaseResource;

--- a/src/Nova/Ranking.php
+++ b/src/Nova/Ranking.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tipoff\Seo\Nova;
+
+use Illuminate\Http\Request;
+use Laravel\Nova\Fields\ID;
+use Laravel\Nova\Fields\Text;
+use Laravel\Nova\Fields\BelongsTo;
+use Laravel\Nova\Http\Requests\NovaRequest;
+use Laravel\Nova\Panel;
+use Tipoff\Support\Nova\BaseResource;
+
+class Ranking extends BaseResource
+{
+    public static $model = \Tipoff\Seo\Models\Ranking::class;
+
+    public static $title = 'engine';
+
+    public static $search = [
+        'id',
+    ];
+
+    public function fieldsForIndex(NovaRequest $request)
+    {
+        return array_filter([
+            ID::make()->sortable(),
+        ]);
+    }
+
+    public function fields(Request $request)
+    {
+        return array_filter([
+            Text::make('Engine')->required()->sortable(),
+            Text::make('Provider')->required()->sortable(),
+            Date::make('Date')->required()->sortable(),
+
+            nova('keyword') ? BelongsTo::make('Keyword', 'keyword', nova('keyword'))->sortable() : null,
+
+            new Panel('Data Fields', $this->dataFields()),
+        ]);
+    }
+
+    public function dataFields(): array
+    {
+        return array_merge(
+            parent::dataFields(),
+            [
+                $this->creatorDataFields(),
+                $this->updaterDataFields(),
+            ]
+        );
+    }
+}

--- a/src/Nova/Ranking.php
+++ b/src/Nova/Ranking.php
@@ -5,10 +5,10 @@ declare(strict_types=1);
 namespace Tipoff\Seo\Nova;
 
 use Illuminate\Http\Request;
+use Laravel\Nova\Fields\BelongsTo;
 use Laravel\Nova\Fields\Date;
 use Laravel\Nova\Fields\ID;
 use Laravel\Nova\Fields\Text;
-use Laravel\Nova\Fields\BelongsTo;
 use Laravel\Nova\Http\Requests\NovaRequest;
 use Laravel\Nova\Panel;
 use Tipoff\Support\Nova\BaseResource;

--- a/src/Nova/Ranking.php
+++ b/src/Nova/Ranking.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tipoff\Seo\Nova;
 
 use Illuminate\Http\Request;
+use Laravel\Nova\Fields\Date;
 use Laravel\Nova\Fields\ID;
 use Laravel\Nova\Fields\Text;
 use Laravel\Nova\Fields\BelongsTo;

--- a/src/Nova/Result.php
+++ b/src/Nova/Result.php
@@ -8,6 +8,7 @@ use Illuminate\Http\Request;
 use Laravel\Nova\Fields\ID;
 use Laravel\Nova\Fields\Text;
 use Laravel\Nova\Fields\BelongsTo;
+use Laravel\Nova\Fields\MorphTo;
 use Laravel\Nova\Http\Requests\NovaRequest;
 use Laravel\Nova\Panel;
 use Tipoff\Support\Nova\BaseResource;

--- a/src/Nova/Result.php
+++ b/src/Nova/Result.php
@@ -5,11 +5,11 @@ declare(strict_types=1);
 namespace Tipoff\Seo\Nova;
 
 use Illuminate\Http\Request;
-use Laravel\Nova\Fields\ID;
-use Laravel\Nova\Fields\Text;
 use Laravel\Nova\Fields\BelongsTo;
+use Laravel\Nova\Fields\ID;
 use Laravel\Nova\Fields\MorphTo;
 use Laravel\Nova\Fields\Number;
+use Laravel\Nova\Fields\Text;
 use Laravel\Nova\Http\Requests\NovaRequest;
 use Laravel\Nova\Panel;
 use Tipoff\Support\Nova\BaseResource;

--- a/src/Nova/Result.php
+++ b/src/Nova/Result.php
@@ -9,6 +9,7 @@ use Laravel\Nova\Fields\ID;
 use Laravel\Nova\Fields\Text;
 use Laravel\Nova\Fields\BelongsTo;
 use Laravel\Nova\Fields\MorphTo;
+use Laravel\Nova\Fields\Number;
 use Laravel\Nova\Http\Requests\NovaRequest;
 use Laravel\Nova\Panel;
 use Tipoff\Support\Nova\BaseResource;

--- a/src/Nova/Result.php
+++ b/src/Nova/Result.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tipoff\Seo\Nova;
+
+use Illuminate\Http\Request;
+use Laravel\Nova\Fields\ID;
+use Laravel\Nova\Fields\Text;
+use Laravel\Nova\Fields\BelongsTo;
+use Laravel\Nova\Http\Requests\NovaRequest;
+use Laravel\Nova\Panel;
+use Tipoff\Support\Nova\BaseResource;
+
+class Result extends BaseResource
+{
+    public static $model = \Tipoff\Seo\Models\Result::class;
+
+    public static $title = 'position';
+
+    public static $search = [
+        'id',
+    ];
+
+    public function fieldsForIndex(NovaRequest $request)
+    {
+        return array_filter([
+            ID::make()->sortable(),
+        ]);
+    }
+
+    public function fields(Request $request)
+    {
+        return array_filter([
+            Text::make('Type')->required()->sortable(),
+            Number::make('Position')->required()->min(0)->max(255)->sortable(),
+
+            nova('ranking') ? BelongsTo::make('Ranking', 'ranking', nova('ranking'))->sortable() : null,
+            MorphTo::make('Resultable')->types([
+                nova('place'),
+                nova('webpage'),
+            ]),
+
+
+            new Panel('Data Fields', $this->dataFields()),
+        ]);
+    }
+
+    public function dataFields(): array
+    {
+        return array_merge(
+            parent::dataFields(),
+        );
+    }
+}

--- a/src/Nova/SearchVolume.php
+++ b/src/Nova/SearchVolume.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tipoff\Seo\Nova;
+
+use Illuminate\Http\Request;
+use Laravel\Nova\Fields\ID;
+use Laravel\Nova\Fields\Text;
+use Laravel\Nova\Fields\BelongsTo;
+use Laravel\Nova\Http\Requests\NovaRequest;
+use Laravel\Nova\Panel;
+use Tipoff\Support\Nova\BaseResource;
+
+class SearchVolume extends BaseResource
+{
+    public static $model = \Tipoff\Seo\Models\SearchVolume::class;
+
+    public static $title = 'engine';
+
+    public static $search = [
+        'id',
+    ];
+
+    public function fieldsForIndex(NovaRequest $request)
+    {
+        return array_filter([
+            ID::make()->sortable(),
+        ]);
+    }
+
+    public function fields(Request $request)
+    {
+        return array_filter([
+            Text::make('Engine')->required()->sortable(),
+            Text::make('Provider')->required()->sortable(),
+            Text::make('Month')->required()->sortable(),
+            Number::make('Queries')->required(),
+            Number::make('Clicks')->nullable(),
+
+            nova('keyword') ? BelongsTo::make('Keyword', 'keyword', nova('keyword'))->sortable() : null,
+
+            new Panel('Data Fields', $this->dataFields()),
+        ]);
+    }
+
+    public function dataFields(): array
+    {
+        return array_merge(
+            parent::dataFields(),
+            [
+                $this->creatorDataFields(),
+                $this->updaterDataFields(),
+            ]
+        );
+    }
+}

--- a/src/Nova/SearchVolume.php
+++ b/src/Nova/SearchVolume.php
@@ -8,6 +8,7 @@ use Illuminate\Http\Request;
 use Laravel\Nova\Fields\ID;
 use Laravel\Nova\Fields\Text;
 use Laravel\Nova\Fields\BelongsTo;
+use Laravel\Nova\Fields\Number;
 use Laravel\Nova\Http\Requests\NovaRequest;
 use Laravel\Nova\Panel;
 use Tipoff\Support\Nova\BaseResource;

--- a/src/Nova/SearchVolume.php
+++ b/src/Nova/SearchVolume.php
@@ -5,10 +5,10 @@ declare(strict_types=1);
 namespace Tipoff\Seo\Nova;
 
 use Illuminate\Http\Request;
-use Laravel\Nova\Fields\ID;
-use Laravel\Nova\Fields\Text;
 use Laravel\Nova\Fields\BelongsTo;
+use Laravel\Nova\Fields\ID;
 use Laravel\Nova\Fields\Number;
+use Laravel\Nova\Fields\Text;
 use Laravel\Nova\Http\Requests\NovaRequest;
 use Laravel\Nova\Panel;
 use Tipoff\Support\Nova\BaseResource;

--- a/src/Nova/Webpage.php
+++ b/src/Nova/Webpage.php
@@ -5,10 +5,10 @@ declare(strict_types=1);
 namespace Tipoff\Seo\Nova;
 
 use Illuminate\Http\Request;
-use Laravel\Nova\Fields\ID;
-use Laravel\Nova\Fields\Text;
 use Laravel\Nova\Fields\BelongsTo;
+use Laravel\Nova\Fields\ID;
 use Laravel\Nova\Fields\MorphMany;
+use Laravel\Nova\Fields\Text;
 use Laravel\Nova\Http\Requests\NovaRequest;
 use Laravel\Nova\Panel;
 use Tipoff\Support\Nova\BaseResource;

--- a/src/Nova/Webpage.php
+++ b/src/Nova/Webpage.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tipoff\Seo\Nova;
+
+use Illuminate\Http\Request;
+use Laravel\Nova\Fields\ID;
+use Laravel\Nova\Fields\Text;
+use Laravel\Nova\Fields\BelongsTo;
+use Laravel\Nova\Fields\MorphMany;
+use Laravel\Nova\Http\Requests\NovaRequest;
+use Laravel\Nova\Panel;
+use Tipoff\Support\Nova\BaseResource;
+
+class Webpage extends BaseResource
+{
+    public static $model = \Tipoff\Seo\Models\Webpage::class;
+
+    public static $title;
+
+    public static $search = [
+        'id',
+    ];
+
+    public function fieldsForIndex(NovaRequest $request)
+    {
+        return array_filter([
+            ID::make()->sortable(),
+        ]);
+    }
+
+    public function fields(Request $request)
+    {
+        return array_filter([
+            Text::make('Path')->required(),
+            Text::make('Subdomain')->nullable(),
+
+            nova('domain') ? BelongsTo::make('Domain', 'domain', nova('domain'))->nullable() : null,
+            app('video') ? BelongsTo::make('Video', 'video', app('video'))->nullable() : null,
+            MorphMany::make('Results'),
+
+            new Panel('Data Fields', $this->dataFields()),
+        ]);
+    }
+
+    public function dataFields(): array
+    {
+        return array_merge(
+            parent::dataFields(),
+            [
+                $this->creatorDataFields(),
+                $this->updaterDataFields(),
+            ]
+        );
+    }
+}

--- a/src/SeoServiceProvider.php
+++ b/src/SeoServiceProvider.php
@@ -38,6 +38,20 @@ class SeoServiceProvider extends TipoffServiceProvider
                 SearchVolume::class => SearchVolumePolicy::class,
                 Webpage::class => WebpagePolicy::class,
             ])
+            ->hasNovaResources([
+                \Tipoff\Seo\Nova\Company::class,
+                \Tipoff\Seo\Nova\CompanyUser::class,
+                \Tipoff\Seo\Nova\Domain::class,
+                \Tipoff\Seo\Nova\Keyword::class,
+                \Tipoff\Seo\Nova\Place::class,
+                \Tipoff\Seo\Nova\PlaceDetails::class,
+                \Tipoff\Seo\Nova\PlaceHours::class,
+                \Tipoff\Seo\Nova\ProfileLink::class,
+                \Tipoff\Seo\Nova\Ranking::class,
+                \Tipoff\Seo\Nova\Result::class,
+                \Tipoff\Seo\Nova\SearchVolume::class,
+                \Tipoff\Seo\Nova\Webpage::class,
+            ])
             ->name('seo')
             ->hasConfigFile();
     }


### PR DESCRIPTION
#45 


- added all Nova resources to Seo
- references Nova resources using Nova helper (Support/config)

Merge this after Support PR (update config with Nova resources)
https://github.com/tipoff/support/pull/87

Note:

- $title is left blank in some resources, could not find appropriate field
-`public static $title;`

- For Nova Polymorphic relation between Result and Place/Webpage, I'm not sure how to write this according to our use of the ternary operator
- included some rules in Nova, not sure if you want to extract that out.