### PR TITLE
Search Locales #44 [TGER-96]

### DIFF
--- a/database/factories/RankingFactory.php
+++ b/database/factories/RankingFactory.php
@@ -7,6 +7,7 @@ namespace Tipoff\Seo\Database\Factories;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Tipoff\Seo\Models\Keyword;
 use Tipoff\Seo\Models\Ranking;
+use Tipoff\Seo\Models\SearchLocale;
 use Tipoff\Seo\Models\Webpage;
 
 class RankingFactory extends Factory
@@ -19,6 +20,7 @@ class RankingFactory extends Factory
             'engine'            => $this->faker->name,
             'provider'          => $this->faker->name,
             'keyword_id'        => Keyword::factory()->create()->id,
+            'search_locale_id'  => SearchLocale::factory()->create()->id,
             'date'              => $this->faker->date('Y-m-D'),
             'creator_id'        => randomOrCreate(app('user')),
             'updater_id'        => randomOrCreate(app('user')),

--- a/database/factories/SearchLocaleFactory.php
+++ b/database/factories/SearchLocaleFactory.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tipoff\Seo\Database\Factories;
 
 use Illuminate\Database\Eloquent\Factories\Factory;
+use Tipoff\Seo\Models\SearchLocale;
 
 class SearchLocaleFactory extends Factory
 {

--- a/database/factories/SearchLocaleFactory.php
+++ b/database/factories/SearchLocaleFactory.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tipoff\Seo\Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class SearchLocaleFactory extends Factory
+{
+    protected $model = SearchLocale::class;
+
+    public function definition()
+    {
+        return [
+            'serp_id'           => $this->faker->randomNumber(),
+            'google_id'         => $this->faker->randomNumber(),
+            'google_parent_id'  => $this->faker->randomNumber(),
+            'name'              => $this->faker->name,
+            'canonical_name'    => $this->faker->name,
+            'country_code'      => $this->faker->countryCode,
+            'target_type'       => 'DMA Region',
+            'reach'             => $this->faker->randomNumber(),
+            'latitude'          => $this->faker->latitude,
+            'longitude'         => $this->faker->longitude,
+            'creator_id'        => randomOrCreate(app('user')),
+            'updater_id'        => randomOrCreate(app('user')),
+        ];
+    }
+}

--- a/database/migrations/2020_01_01_141000_create_search_locales_table.php
+++ b/database/migrations/2020_01_01_141000_create_search_locales_table.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateSearchLocalesTable extends Migration
+{
+    public function up()
+    {
+        Schema::create('search_locales', function (Blueprint $table) {
+            $table->id();
+            $table->string('serp_id')->index();
+            $table->unsignedInteger('google_id');
+            $table->unsignedInteger('google_parent_id');
+            $table->string('name')->unique();
+            $table->string('canonical_name');
+            $table->string('country_code');
+            $table->string('target_type');
+            $table->unsignedInteger('reach');
+            $table->decimal('latitude', 10, 8);
+            $table->decimal('longitude', 11, 8);
+
+            $table->foreignIdFor(app('user'), 'creator_id')->nullable(); // Probably not ever used here, but just in case it is a requested run
+            $table->foreignIdFor(app('user'), 'updater_id')->nullable(); // There may later be a few fields that are updatable, but most will be locked to not be editable
+            $table->timestamps();
+        });
+    }
+}

--- a/database/migrations/2020_01_01_150000_create_rankings_table.php
+++ b/database/migrations/2020_01_01_150000_create_rankings_table.php
@@ -25,7 +25,7 @@ class CreateRankingsTable extends Migration
             $table->foreignIdFor(app('user'), 'updater_id')->nullable(); // There may later be a few fields that are updatable, but most will be locked to not be editable
             $table->timestamps();
 
-            $table->unique(['engine', 'provider', 'keyword_id', 'date']);
+            $table->unique(['engine', 'provider', 'keyword_id', 'search_locale_id', 'date']);
         });
     }
 }

--- a/database/migrations/2020_01_01_150000_create_rankings_table.php
+++ b/database/migrations/2020_01_01_150000_create_rankings_table.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 use Tipoff\Seo\Models\Keyword;
+use Tipoff\Seo\Models\SearchLocale;
 
 class CreateRankingsTable extends Migration
 {
@@ -16,6 +17,8 @@ class CreateRankingsTable extends Migration
             $table->string('engine')->index(); // Example: 'google', 'youtube', 'bing' (haha)
             $table->string('provider')->index(); // Example: 'serpapi', 'moz', 'ahrefs'
             $table->foreignIdFor(Keyword::class)->index();
+            $table->foreignIdFor(SearchLocale::class)->index();
+            
             $table->date('date')->index();
 
             $table->foreignIdFor(app('user'), 'creator_id')->nullable(); // Probably not ever used here, but just in case it is a requested run

--- a/src/Models/Ranking.php
+++ b/src/Models/Ranking.php
@@ -19,4 +19,9 @@ class Ranking extends BaseModel
     {
         return $this->hasMany(Result::class);
     }
+
+    public function searchLocale()
+    {
+        return $this->belongsTo(SearchLocale::class);
+    }
 }

--- a/src/Models/SearchLocale.php
+++ b/src/Models/SearchLocale.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tipoff\Seo\Models;
+
+use Tipoff\Support\Models\BaseModel;
+use Tipoff\Support\Traits\HasCreator;
+use Tipoff\Support\Traits\HasPackageFactory;
+use Tipoff\Support\Traits\HasUpdater;
+
+class SearchLocale extends BaseModel
+{
+    use HasPackageFactory;
+    use HasCreator;
+    use HasUpdater;
+
+    public function rankings()
+    {
+        return $this->hasMany(Ranking::class);
+    }
+}

--- a/tests/Unit/Models/SearchLocaleModelTest.php
+++ b/tests/Unit/Models/SearchLocaleModelTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tipoff\Seo\Tests\Unit\Models;
+
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Tipoff\Seo\Models\SearchLocale;
+use Tipoff\Seo\Tests\TestCase;
+
+class SearchLocaleModelTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    /** @test */
+    public function create()
+    {
+        $model = SearchLocale::factory()->create();
+        $this->assertNotNull($model);
+    }
+}


### PR DESCRIPTION
closes #44 
#2 

- add Model SearchLocale
- add Migration for SearchLocales
- add relationship in Model Ranking belongsTo SearchLocale
- add SearchLocale FK to Migration Ranking
- add SearchLocale FK to Migration Ranking Index 
- create Factory for SearchLocale
- fix Factory for Ranking

_Note:_ 

- Migration SearchLocale, two ids (ours / API id)
- https://serpapi.com/locations-api
- not sure if the API ID is "1 to 1" with 'google_id'
- Col 'reach' max ~4 billion
- did not add _Nova resource_ SearchLocale