### PR TITLE
Omnia/feature/50 implement registry pattern

### DIFF
--- a/src/Registries/ProviderRegistry.php
+++ b/src/Registries/ProviderRegistry.php
@@ -14,7 +14,6 @@ class ProviderRegistry
      * @param TipoffServiceProvider $instance
      * return $this
      */
-
     public function registerProvider(TipoffServiceProvider $instance): self
     {
         $this->providers[$instance->name()] = $instance;
@@ -26,7 +25,6 @@ class ProviderRegistry
      * @param string $name
      * return TipoffServiceProvider $provider
      */
-
     public function getProvider(string $name)
     {
         $provider = $this->providers[$name];

--- a/src/Registries/ProviderRegistry.php
+++ b/src/Registries/ProviderRegistry.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tipoff\Seo\Registries;
+
+use Tipoff\Support\TipoffServiceProvider;
+
+class ProviderRegistry
+{
+    protected array $providers = [];
+
+    /**
+     * @param TipoffServiceProvider $instance
+     * return $this
+     */
+
+    public function registerProvider(TipoffServiceProvider $instance): self
+    {
+        $this->providers[$instance->name()] = $instance;
+
+        return $this;
+    }
+
+    /**
+     * @param string $name
+     * return TipoffServiceProvider $provider
+     */
+
+    public function getProvider(string $name)
+    {
+        $provider = $this->providers[$name];
+
+        return $provider;
+    }
+}

--- a/src/SeoServiceProvider.php
+++ b/src/SeoServiceProvider.php
@@ -51,4 +51,9 @@ class SeoServiceProvider extends TipoffServiceProvider
             ->name('seo')
             ->hasConfigFile();
     }
+
+    public function name(): string
+    {
+        return 'seo';
+    }
 }

--- a/src/SeoServiceProvider.php
+++ b/src/SeoServiceProvider.php
@@ -18,11 +18,17 @@ use Tipoff\Seo\Policies\PlacePolicy;
 use Tipoff\Seo\Policies\RankingPolicy;
 use Tipoff\Seo\Policies\SearchVolumePolicy;
 use Tipoff\Seo\Policies\WebpagePolicy;
+use Tipoff\Seo\Registries\ProviderRegistry;
 use Tipoff\Support\TipoffPackage;
 use Tipoff\Support\TipoffServiceProvider;
 
 class SeoServiceProvider extends TipoffServiceProvider
 {
+    public function registeringPackage()
+    {
+        $this->app->singleton(ProviderRegistry::class);
+    }
+
     public function configureTipoffPackage(TipoffPackage $package): void
     {
         $package

--- a/src/SeoServiceProvider.php
+++ b/src/SeoServiceProvider.php
@@ -29,6 +29,18 @@ class SeoServiceProvider extends TipoffServiceProvider
         $this->app->singleton(ProviderRegistry::class);
     }
 
+    public function bootingPackage()
+    {
+        parent::bootingPackage();
+
+        // example to register providers
+
+        // $this->app->make(ProviderRegistry::class)
+        //     ->register(new SerpApiProvider)
+        //     ->register(new AhrefsProvider)
+        //     ->register(new MozProvider);
+    }
+
     public function configureTipoffPackage(TipoffPackage $package): void
     {
         $package


### PR DESCRIPTION
#50 

- created ProviderRegistry for swapping providers
- add name method from Support/TipoffServiceProvider abstract method
- SeoServiceProvider add method registeringPackage( )
- SeoServiceProvider add method bootingPackage( ) with example for registering providers

Can resolve providers like this
```
/** @var ProviderRegistry $registry */
$registry = app(ProviderRegistry::class)

$registry->getProvider('serp-api')->search('escape room florida');
$registry->getProvider('ahrefs')->search('escape room florida');
$registry->getProvider('moz')->search('escape room florida');
```