### PR TITLE
set name of index - index name too long error

### DIFF
--- a/database/migrations/2020_01_01_131000_create_business_categorizables_table.php
+++ b/database/migrations/2020_01_01_131000_create_business_categorizables_table.php
@@ -12,7 +12,7 @@ class CreateBusinessCategorizablesTable extends Migration
             $table->foreignIdFor(app('business_category'));
             $table->morphs('categorizable');
 
-            $table->unique(['business_category_id', 'categorizable_id', 'categorizable_type']);
+            $table->unique(['business_category_id', 'categorizable_id', 'categorizable_type'], 'categorizable_unique');
         });
     }
 }


### PR DESCRIPTION
when migration run, mysql giving error `'business_categorizables_categorizable_type_categorizable_id_index' is too long`, set name of index