### PR TITLE
Add Google Search Console to check keyword search volumes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,15 +17,15 @@
     "require": {
         "php": "^7.3|^8.0",
         "drewroberts/media": "^3.5.0",
-        "tipoff/addresses": "^2.8.8",
-        "tipoff/authorization": "^2.8.5",
-        "tipoff/laravel-google-api": "^2.0.0",
+        "schulzefelix/laravel-search-console": "^1.7",
+        "tipoff/addresses": "^2.8.10",
+        "tipoff/authorization": "^2.8.6",
+        "tipoff/laravel-google-api": "^2.1.0",
         "tipoff/laravel-serpapi": "^2.0.0",
-        "tipoff/support": "^2.1.3",
-        "schulzefelix/laravel-search-console": "^1.7"
+        "tipoff/support": "^2.1.5"
     },
     "require-dev": {
-        "tipoff/test-support": "^2.0.0"
+        "tipoff/test-support": "^2.0.1"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
         "tipoff/authorization": "^2.8.5",
         "tipoff/laravel-google-api": "^2.0.0",
         "tipoff/laravel-serpapi": "^2.0.0",
-        "tipoff/support": "^2.1.3"
+        "tipoff/support": "^2.1.3",
+        "schulzefelix/laravel-search-console": "^1.7"
     },
     "require-dev": {
         "tipoff/test-support": "^2.0.0"

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         }
     ],
     "require": {
-        "php": "^7.3|^8.0",
+        "php": "^7.4|^8.0",
         "drewroberts/media": "^3.5.0",
         "schulzefelix/laravel-search-console": "^1.7",
         "tipoff/addresses": "^2.8.10",

--- a/config/seo.php
+++ b/config/seo.php
@@ -1,5 +1,9 @@
 <?php
 
 return [
-    'serp_api_key' => env('SERP_API_KEY')
+    'serp_api_key' => env('SERP_API_KEY'),
+
+    'perform_on_queue' => [
+        'check_keyword_search_volume' => 'default'
+    ]
 ];

--- a/src/Commands/CheckSearchVolumeCommand.php
+++ b/src/Commands/CheckSearchVolumeCommand.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tipoff\Seo\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Bus;
+use SchulzeFelix\SearchConsole\Period;
+use SchulzeFelix\SearchConsole\SearchConsoleFacade as SearchConsole;
+use Tipoff\GoogleApi\Facades\GoogleOauth;
+use Tipoff\Seo\Jobs\CheckKeywordSearchVolumeJob;
+
+class CheckSearchVolumeCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'keywords:check-search-volume {url} {--limit=1000}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Pull data from Google Search Console and update keyword search volumes.';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        // Get access token from Google Oauth package.
+        $accessToken = GoogleOauth::accessToken('google-console');
+
+        $batch = Bus::batch([])
+            ->name('check-keyword-search-volume-' . date('Y-m-d'))
+            ->allowFailures()
+            ->onQueue(config('seo.perform_on_queue.check_keyword_search_volume'))
+            ->dispatch();
+
+        /**
+         * Using SearchConsole Facade directly here,
+         * we might need to use registry pattern when we have more provider like Ahrefs or Semrush, etc.
+         */
+        SearchConsole::setAccessToken($accessToken->getAccessToken())
+            ->setQuotaUser('uniqueQuotaUserString')
+            ->searchAnalyticsQuery(
+                $this->argument('url'),
+                Period::create(now()->subDays(30), now()->subDays(2)),
+                ['query'],
+                [],
+                (int)$this->option('limit'),
+                'web',
+                'all',
+                'auto'
+            )
+            ->map(fn(array $payload) => $this->createCheckSearchVolumeJob($payload))
+            ->chunk(1000)
+            ->each(fn(Collection $jobs) => $batch->add($jobs));
+    }
+
+    /**
+     * @param array $payload
+     * @return CheckKeywordSearchVolumeJob
+     */
+    private function createCheckSearchVolumeJob(array $payload)
+    {
+        return new CheckKeywordSearchVolumeJob(
+            $payload,
+            'google',
+            'google-console',
+            date('Y-m')
+        );
+    }
+}

--- a/src/Commands/CheckSearchVolumeCommand.php
+++ b/src/Commands/CheckSearchVolumeCommand.php
@@ -60,7 +60,10 @@ class CheckSearchVolumeCommand extends Command
             )
             ->map(fn (array $payload) => $this->createCheckSearchVolumeJob($payload))
             ->chunk(1000)
-            ->each(fn (Collection $jobs) => $batch->add($jobs));
+            ->each(function (Collection $jobs) use ($batch) {
+                // Non-arrow function keeps psalm happy for $batch usage
+                $batch->add($jobs);
+            });
     }
 
     /**

--- a/src/Commands/CheckSearchVolumeCommand.php
+++ b/src/Commands/CheckSearchVolumeCommand.php
@@ -58,9 +58,9 @@ class CheckSearchVolumeCommand extends Command
                 'all',
                 'auto'
             )
-            ->map(fn(array $payload) => $this->createCheckSearchVolumeJob($payload))
+            ->map(fn (array $payload) => $this->createCheckSearchVolumeJob($payload))
             ->chunk(1000)
-            ->each(fn(Collection $jobs) => $batch->add($jobs));
+            ->each(fn (Collection $jobs) => $batch->add($jobs));
     }
 
     /**

--- a/src/Jobs/CheckKeywordSearchVolumeJob.php
+++ b/src/Jobs/CheckKeywordSearchVolumeJob.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tipoff\Seo\Jobs;
+
+use Illuminate\Bus\Batchable;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Support\Arr;
+use Tipoff\Seo\Models\Keyword;
+
+class CheckKeywordSearchVolumeJob implements ShouldQueue
+{
+    use InteractsWithQueue;
+    use Queueable;
+    use Dispatchable;
+    use Batchable;
+
+    private array $payload;
+    private string $engine;
+    private string $provider;
+    private $rangeValue;
+    private string $range;
+
+    /**
+     * Create a new job instance.
+     *
+     * @return void
+     */
+    public function __construct(array $payload, string $engine, string $provider, $rangeValue, $range = 'month')
+    {
+        $this->payload = $payload;
+        $this->engine = $engine;
+        $this->provider = $provider;
+        $this->rangeValue = $rangeValue;
+        $this->range = $range;
+    }
+
+    /**
+     * Handle the job.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        /** @var Keyword $keyword */
+        $keyword = Keyword::where('phrase', Arr::get($this->payload, 'query'))->first();
+
+        if (!$keyword) {
+            return;
+        }
+
+        $keyword->searchVolume()->updateOrCreate(
+            [
+                'keyword_id' => $keyword->id,
+                'engine'     => $this->engine,
+                'provider'   => $this->provider,
+            ],
+            [
+                'range'       => $this->range,
+                'range_value' => $this->rangeValue,
+                'queries'     => Arr::get($this->payload, 'impressions'),
+                'clicks'      => Arr::get($this->payload, 'clicks')
+            ]
+        );
+    }
+}

--- a/src/Jobs/CheckKeywordSearchVolumeJob.php
+++ b/src/Jobs/CheckKeywordSearchVolumeJob.php
@@ -49,21 +49,21 @@ class CheckKeywordSearchVolumeJob implements ShouldQueue
         /** @var Keyword $keyword */
         $keyword = Keyword::where('phrase', Arr::get($this->payload, 'query'))->first();
 
-        if (!$keyword) {
+        if (! $keyword) {
             return;
         }
 
         $keyword->searchVolume()->updateOrCreate(
             [
                 'keyword_id' => $keyword->id,
-                'engine'     => $this->engine,
-                'provider'   => $this->provider,
+                'engine' => $this->engine,
+                'provider' => $this->provider,
             ],
             [
-                'range'       => $this->range,
+                'range' => $this->range,
                 'range_value' => $this->rangeValue,
-                'queries'     => Arr::get($this->payload, 'impressions'),
-                'clicks'      => Arr::get($this->payload, 'clicks')
+                'queries' => Arr::get($this->payload, 'impressions'),
+                'clicks' => Arr::get($this->payload, 'clicks'),
             ]
         );
     }

--- a/src/Models/Keyword.php
+++ b/src/Models/Keyword.php
@@ -20,7 +20,7 @@ class Keyword extends BaseModel
 
     protected $casts = [
         'tracking_requested_at' => 'datetime',
-        'tracking_stopped_at'   => 'datetime',
+        'tracking_stopped_at' => 'datetime',
     ];
 
     protected static function boot()

--- a/src/Models/Keyword.php
+++ b/src/Models/Keyword.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Tipoff\Seo\Models;
 
@@ -20,7 +20,7 @@ class Keyword extends BaseModel
 
     protected $casts = [
         'tracking_requested_at' => 'datetime',
-        'tracking_stopped_at' => 'datetime',
+        'tracking_stopped_at'   => 'datetime',
     ];
 
     protected static function boot()
@@ -32,8 +32,8 @@ class Keyword extends BaseModel
         });
         static::addGlobalScope('active', function (Builder $builder) {
             $builder->whereDate('keywords.tracking_requested_at', '<=', date('Y-m-d')) &&
-                    ($builder->whereDate('keywords.tracking_stopped_at', '>=', date('Y-m-d'))
-                            ->orWhereNull('keywords.tracking_stopped_at'));
+            ($builder->whereDate('keywords.tracking_stopped_at', '>=', date('Y-m-d'))
+                ->orWhereNull('keywords.tracking_stopped_at'));
         });
     }
 
@@ -70,5 +70,10 @@ class Keyword extends BaseModel
     public function rankings()
     {
         return $this->hasMany(app('ranking'));
+    }
+
+    public function searchVolume()
+    {
+        return $this->hasOne(SearchVolume::class);
     }
 }

--- a/src/SeoServiceProvider.php
+++ b/src/SeoServiceProvider.php
@@ -59,7 +59,7 @@ class SeoServiceProvider extends TipoffServiceProvider
             ->hasCommands([
                 CheckRankingCommand::class,
                 PullSearchLocales::class,
-                CheckSearchVolumeCommand::class
+                CheckSearchVolumeCommand::class,
             ])
             ->name('seo')
             ->hasConfigFile();

--- a/src/SeoServiceProvider.php
+++ b/src/SeoServiceProvider.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tipoff\Seo;
 
 use Tipoff\Seo\Commands\CheckRankingCommand;
+use Tipoff\Seo\Commands\CheckSearchVolumeCommand;
 use Tipoff\Seo\Commands\PullSearchLocales;
 use Tipoff\Seo\Models\BusinessCategory;
 use Tipoff\Seo\Models\Company;
@@ -58,6 +59,7 @@ class SeoServiceProvider extends TipoffServiceProvider
             ->hasCommands([
                 CheckRankingCommand::class,
                 PullSearchLocales::class,
+                CheckSearchVolumeCommand::class
             ])
             ->name('seo')
             ->hasConfigFile();


### PR DESCRIPTION
Add ability to check keyword search volumes from Google Search Console via this command:

```
php artisan keywords:check-search-volume https://tuikhoeconban.com --limit=1000
```

This will pull data from Google Search Console and check with our database. If we have that keyword in the database, then it will create or update the search volumes data in `search_volumes` table.

**Notice:** This PR requires changes from this PR (https://github.com/tipoff/laravel-google-api/pull/36) to work.

This is the video I demonstrated how it works: https://www.youtube.com/watch?v=qglfB5efRHY